### PR TITLE
feat(ui): SuggestionCard/EditPlanSheet/TwoChoicePrompt/RecoveryBanner…

### DIFF
--- a/components/EditPlanSheet.tsx
+++ b/components/EditPlanSheet.tsx
@@ -1,0 +1,59 @@
+// components/EditPlanSheet.tsx
+import React, { useState } from "react";
+import { View, Text, TouchableOpacity, Modal, StyleSheet } from "react-native";
+import type { Plan } from "@/types/plan";
+
+type Props = {
+  plan: Plan;
+  visible: boolean;
+  onSave: (updated: Plan) => void;
+  onCancel: () => void;
+};
+
+export default function EditPlanSheet({ plan, visible, onSave, onCancel }: Props) {
+  const [time, setTime] = useState(plan.totalTime);
+  const [intensity, setIntensity] = useState<"low" | "med" | "high">(plan.blocks[0].intensity);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide">
+      <View style={styles.sheet}>
+        <Text style={styles.header}>Edit Plan</Text>
+
+        <Text>Time:</Text>
+        <View style={styles.row}>
+          {[15, 20, 25, 30].map((t) => (
+            <TouchableOpacity key={t} style={styles.choice} onPress={() => setTime(t)}>
+              <Text style={{ fontWeight: t === time ? "bold" : "normal" }}>{t}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <Text>Intensity:</Text>
+        <View style={styles.row}>
+          {["low", "med", "high"].map((i) => (
+            <TouchableOpacity key={i} style={styles.choice} onPress={() => setIntensity(i as any)}>
+              <Text style={{ fontWeight: i === intensity ? "bold" : "normal" }}>{i}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        <View style={styles.actions}>
+          <TouchableOpacity onPress={() => onSave({ ...plan, totalTime: time })}>
+            <Text>✅ Save</Text>
+          </TouchableOpacity>
+          <TouchableOpacity onPress={onCancel}>
+            <Text>❌ Cancel</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  sheet: { backgroundColor: "#fff", marginTop: "auto", padding: 16, borderTopLeftRadius: 16, borderTopRightRadius: 16 },
+  header: { fontSize: 18, fontWeight: "bold", marginBottom: 12 },
+  row: { flexDirection: "row", marginVertical: 8 },
+  choice: { marginHorizontal: 8, padding: 6, backgroundColor: "#eee", borderRadius: 6 },
+  actions: { flexDirection: "row", justifyContent: "space-around", marginTop: 16 },
+});

--- a/components/RecoveryBanner.tsx
+++ b/components/RecoveryBanner.tsx
@@ -1,0 +1,34 @@
+// components/RecoveryBanner.tsx
+import React from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+
+type Props = {
+  rationale: string;
+  onRecover: () => void;
+  onKeepNormal: () => void;
+};
+
+export default function RecoveryBanner({ rationale, onRecover, onKeepNormal }: Props) {
+  return (
+    <View style={styles.banner}>
+      <Text style={styles.header}>⚠️ Recovery Suggestion</Text>
+      <Text style={styles.text}>{rationale}</Text>
+      <View style={styles.actions}>
+        <TouchableOpacity style={styles.btn} onPress={onRecover}>
+          <Text>🌿 Recover Today</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.btn} onPress={onKeepNormal}>
+          <Text>➡️ Keep Normal</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: { backgroundColor: "#fffbe6", padding: 16, margin: 12, borderRadius: 12, borderColor: "#ffcc00", borderWidth: 1 },
+  header: { fontWeight: "bold", marginBottom: 6 },
+  text: { marginBottom: 8 },
+  actions: { flexDirection: "row", justifyContent: "space-around" },
+  btn: { padding: 8, backgroundColor: "#eee", borderRadius: 6 },
+});

--- a/components/SuggestionCard.tsx
+++ b/components/SuggestionCard.tsx
@@ -1,0 +1,55 @@
+// components/SuggestionCard.tsx
+import React from "react";
+import { View, Text, TouchableOpacity, StyleSheet, FlatList } from "react-native";
+import type { Plan } from "@/types/plan";
+
+type Props = {
+  plan: Plan;
+  onStart: (plan: Plan) => void;
+  onEdit: (plan: Plan) => void;
+  onRefresh: () => void;
+};
+
+export default function SuggestionCard({ plan, onStart, onEdit, onRefresh }: Props) {
+  return (
+    <View style={styles.card}>
+      <Text style={styles.header}>Today’s Plan</Text>
+      <Text style={styles.title}>🏷️ {plan.title}</Text>
+      <Text style={styles.section}>⏱️ Blocks:</Text>
+      <FlatList
+        data={plan.blocks}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <Text style={styles.block}>
+            • {item.title} ({item.duration}m{item.met ? `, MET ${item.met}` : ""})
+          </Text>
+        )}
+      />
+      <Text style={styles.section}>
+        📌 Why this? {plan.why.join(" ")}
+      </Text>
+
+      <View style={styles.actions}>
+        <TouchableOpacity style={styles.btn} onPress={() => onStart(plan)}>
+          <Text>▶ Start</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.btn} onPress={() => onEdit(plan)}>
+          <Text>✏ Edit</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.btn} onPress={onRefresh}>
+          <Text>↻ Refresh</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: { backgroundColor: "#fff", padding: 16, margin: 12, borderRadius: 12, elevation: 2 },
+  header: { fontSize: 18, fontWeight: "bold", marginBottom: 8 },
+  title: { fontSize: 16, marginBottom: 8 },
+  section: { marginTop: 8, fontWeight: "600" },
+  block: { marginLeft: 12, fontSize: 14 },
+  actions: { flexDirection: "row", justifyContent: "space-between", marginTop: 12 },
+  btn: { padding: 8, backgroundColor: "#eee", borderRadius: 8 },
+});

--- a/components/TwoChoicePrompt.tsx
+++ b/components/TwoChoicePrompt.tsx
@@ -1,0 +1,35 @@
+// components/TwoChoicePrompt.tsx
+import React, { useEffect } from "react";
+import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
+
+type Props = {
+  onChoice: (bias: "harder" | "easier" | "none") => void;
+};
+
+export default function TwoChoicePrompt({ onChoice }: Props) {
+  useEffect(() => {
+    const timer = setTimeout(() => onChoice("none"), 3000);
+    return () => clearTimeout(timer);
+  }, [onChoice]);
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.header}>How do you feel today? (auto close in 3s)</Text>
+      <View style={styles.row}>
+        <TouchableOpacity style={styles.choice} onPress={() => onChoice("harder")}>
+          <Text>💥 Push harder</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.choice} onPress={() => onChoice("easier")}>
+          <Text>🌿 Take it easy</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: { backgroundColor: "#fff", padding: 16, margin: 12, borderRadius: 12, elevation: 2 },
+  header: { fontSize: 16, fontWeight: "600", marginBottom: 12 },
+  row: { flexDirection: "row", justifyContent: "space-around" },
+  choice: { padding: 12, backgroundColor: "#eee", borderRadius: 8 },
+});

--- a/hooks/usePlanSuggestion.ts
+++ b/hooks/usePlanSuggestion.ts
@@ -1,0 +1,22 @@
+import type { Plan } from '@/types/plan';
+
+const mockPlan20m: Plan = {
+  title: 'Mindful Mobility + Light Cardio (20m)',
+  blocks: [
+    { id: 'mob_cat_cow_5', title: 'Cat–Cow', duration: 5, met: 2.0, intensity: 'low', category: 'mobility' },
+    { id: 'mind_box_breath_5', title: 'Box Breathing', duration: 5, met: 1.5, intensity: 'low', category: 'mindfulness' },
+    { id: 'card_walk_liss_10', title: 'Walk LISS', duration: 10, met: 3.0, intensity: 'med', category: 'cardio' }
+  ],
+  totalTime: 20,
+  why: ['Monotony trending high → add variety & lower strain.']
+};
+
+export type SuggestionCtx = {
+  timeAvailable: number;
+  readiness?: number; // < 40 → show Two-Choice
+};
+
+export function usePlanSuggestion(ctx: SuggestionCtx): { plan: Plan; isUncertainDay: boolean } {
+  const isUncertainDay = (ctx.readiness ?? 100) < 40;
+  return { plan: mockPlan20m, isUncertainDay };
+}


### PR DESCRIPTION
Title: feat(ui): suggestion UI (2.3) with mock hook
Body:
- Renders Plan DTO (mock)
- Two-Choice prompt on readiness < 40 (auto-close 3s)
- Recovery banner placeholder (wired for later A logic)
- Non-destructive; switches to A later via usePlanSuggestion
